### PR TITLE
Added Rain Sensor to netatmo.py

### DIFF
--- a/src/netatmo/netatmo.py
+++ b/src/netatmo/netatmo.py
@@ -600,6 +600,18 @@ def fetch(rc_file_or_dict=None):
                 )
             except KeyError:
                 pass
+            try:
+                data_type = ["Rain"]
+                dl_csv(
+                    ws,
+                    f"netatmo_module_rain.csv",
+                    station["_id"],
+                    module["_id"],
+                    data_type,
+                    module["dashboard_data"]["time_utc"],
+                )
+            except KeyError:
+                pass
 
 
 def self_test(args):


### PR DESCRIPTION
The download of Rain data didn't work as there was no check for the data_type "Rain". This is a quick and dirty hack but works (as of May 2023).